### PR TITLE
Mute audio when program set to aux

### DIFF
--- a/src/atemSwitcher.ino
+++ b/src/atemSwitcher.ino
@@ -281,7 +281,7 @@ void updateATEM() {
             if(videoSourceState == 2){
                 AtemSwitcher.changeAudioChannelMode(1101,0); //Mute Studio Audio
                 AtemSwitcher.changeAudioChannelMode(2,1); //UnMute Pi Audio
-            } else if(lastVideoSourceState == 2) {
+            } else{
                 AtemSwitcher.changeAudioChannelMode(1101,1); //UnMute Studio Audio
                 AtemSwitcher.changeAudioChannelMode(2,0); //Mute Pi Audio
             }

--- a/src/atemSwitcher.ino
+++ b/src/atemSwitcher.ino
@@ -278,12 +278,12 @@ void updateATEM() {
             } else {
                 AtemSwitcher.doCut();
             }
-            if(videoSourceState == ){
-                //Mute Studio Audio
-                //UnMute Pi Audio
-            } elseif(lastVideoSourceState == ) {
-                //UnMute Studio Audio
-                //Mute Pi Audio
+            if(videoSourceState == 2){
+                AtemSwitcher.changeAudioChannelMode(1101,0); //Mute Studio Audio
+                AtemSwitcher.changeAudioChannelMode(2,1); //UnMute Pi Audio
+            } elseif(lastVideoSourceState == 2) {
+                AtemSwitcher.changeAudioChannelMode(1101,1); //UnMute Studio Audio
+                AtemSwitcher.changeAudioChannelMode(2,0); //Mute Pi Audio
             }
             doCut = false;
         }

--- a/src/atemSwitcher.ino
+++ b/src/atemSwitcher.ino
@@ -151,13 +151,7 @@ void loop() {
 
     updateState();
     updateATEM();
-    if(AtemSwitcher.getProgramInput() == 2){
-        AtemSwitcher.changeAudioChannelMode(1101,0); //Mute Studio Audio
-        AtemSwitcher.changeAudioChannelMode(2,1); //UnMute Pi Audio
-    } else{
-        AtemSwitcher.changeAudioChannelMode(1101,1); //UnMute Studio Audio
-        AtemSwitcher.changeAudioChannelMode(2,0); //Mute Pi Audio
-    }
+    muteMainAudio();
 }
 
 void readMic(uint8_t index) {
@@ -181,6 +175,16 @@ void readMic(uint8_t index) {
         debounce(LOW, index, &lastMicState, &micState, debounceMic, MIC_DEBOUNCE_MS);
     } else {
         debounce(HIGH, index, &lastMicState, &micState, debounceMic, MIC_DEBOUNCE_MS);
+    }
+}
+
+void muteMainAudio(void){
+    if(AtemSwitcher.getProgramInput() == 2){ // If the current program input is equal to camera 2.
+        AtemSwitcher.changeAudioChannelMode(1101,0); //Mute Studio Audio
+        AtemSwitcher.changeAudioChannelMode(2,1); //UnMute Pi Audio
+    } else{
+        AtemSwitcher.changeAudioChannelMode(1101,1); //UnMute Studio Audio
+        AtemSwitcher.changeAudioChannelMode(2,0); //Mute Pi Audio
     }
 }
 

--- a/src/atemSwitcher.ino
+++ b/src/atemSwitcher.ino
@@ -152,7 +152,7 @@ void loop() {
 
     updateState();
     updateATEM();
-    muteMainAudio();
+    updateAudioOutput();
 }
 
 void readMic(uint8_t index) {
@@ -179,7 +179,7 @@ void readMic(uint8_t index) {
     }
 }
 
-void muteMainAudio(void){
+void updateAudioOutput(void){
     if(AtemSwitcher.getProgramInput() == 2){ // If the current program input is equal to camera 2.
         AtemSwitcher.changeAudioChannelMode(1101,0); //Mute Studio Audio
         AtemSwitcher.changeAudioChannelMode(2,1); //UnMute Pi Audio

--- a/src/atemSwitcher.ino
+++ b/src/atemSwitcher.ino
@@ -281,7 +281,7 @@ void updateATEM() {
             if(videoSourceState == 2){
                 AtemSwitcher.changeAudioChannelMode(1101,0); //Mute Studio Audio
                 AtemSwitcher.changeAudioChannelMode(2,1); //UnMute Pi Audio
-            } elseif(lastVideoSourceState == 2) {
+            } else if(lastVideoSourceState == 2) {
                 AtemSwitcher.changeAudioChannelMode(1101,1); //UnMute Studio Audio
                 AtemSwitcher.changeAudioChannelMode(2,0); //Mute Pi Audio
             }

--- a/src/atemSwitcher.ino
+++ b/src/atemSwitcher.ino
@@ -62,24 +62,25 @@ Button modeButton(7, PULLUP, INVERT, DEBOUNCE_MS);
 
 // Mapping
 const uint16_t micToVideoSource[16] = {
-    5, // 0000 No mics
+       // 321P Bits correspond to mics (G3 G2 G1 Pres)
+    3, // 0000 No mics
     1, // 0001 Presenter Mic
-    5, // 0010 Guest 1
-    5, // 0011 P & G1
-    5, // 0100 G2
-    5, // 0101 P & G2
-    5, // 0110 G1 & G2
-    5, // 0111 P & G1 & G2
-    5, // 1000 G3
-    5, // 1001 P & G3
-    5, // 1010 G1 & G3
-    5, // 1011 P & G1 & G3
-    5, // 1100 G2 & G3
-    5, // 1101 P & G2 & G3
-    5, // 1110 G1 & G2 & G3
-    5, // 1111 P & G1 & G2 & G3
+    3, // 0010 Guest 1
+    1, // 0011 P & G1
+    3, // 0100 G2
+    3, // 0101 P & G2
+    3, // 0110 G1 & G2
+    3, // 0111 P & G1 & G2
+    3, // 1000 G3
+    3, // 1001 P & G3
+    3, // 1010 G1 & G3
+    3, // 1011 P & G1 & G3
+    3, // 1100 G2 & G3
+    3, // 1101 P & G2 & G3
+    3, // 1110 G1 & G2 & G3
+    3, // 1111 P & G1 & G2 & G3
 };
-const uint16_t defaultVideoSource = 5;
+const uint16_t defaultVideoSource = 3;
 
 // Network Config
 byte mac[] = {0x90, 0xA2, 0xDA, 0x0D, 0x6B, 0xB9};

--- a/src/atemSwitcher.ino
+++ b/src/atemSwitcher.ino
@@ -278,6 +278,13 @@ void updateATEM() {
             } else {
                 AtemSwitcher.doCut();
             }
+            if(videoSourceState == ){
+                //Mute Studio Audio
+                //UnMute Pi Audio
+            } elseif(lastVideoSourceState == ) {
+                //UnMute Studio Audio
+                //Mute Pi Audio
+            }
             doCut = false;
         }
     }
@@ -353,5 +360,4 @@ void updateFromATEM() {
     shiftOut(dataPin, clockPin, MSBFIRST, greenLeds);
     shiftOut(dataPin, clockPin, MSBFIRST, redLeds);
     digitalWrite(latchPin, HIGH);
-
 }

--- a/src/atemSwitcher.ino
+++ b/src/atemSwitcher.ino
@@ -269,6 +269,7 @@ void updateATEM() {
             lastAutoChange = millis();
         }
     } else { // modeState == manual
+
         if (videoSourceState != lastVideoSourceState) {
             AtemSwitcher.changePreviewInput(videoSourceState);
         }
@@ -278,6 +279,7 @@ void updateATEM() {
             } else {
                 AtemSwitcher.doCut();
             }
+
             if(videoSourceState == 2){
                 AtemSwitcher.changeAudioChannelMode(1101,0); //Mute Studio Audio
                 AtemSwitcher.changeAudioChannelMode(2,1); //UnMute Pi Audio
@@ -285,6 +287,7 @@ void updateATEM() {
                 AtemSwitcher.changeAudioChannelMode(1101,1); //UnMute Studio Audio
                 AtemSwitcher.changeAudioChannelMode(2,0); //Mute Pi Audio
             }
+
             doCut = false;
         }
     }

--- a/src/atemSwitcher.ino
+++ b/src/atemSwitcher.ino
@@ -151,6 +151,13 @@ void loop() {
 
     updateState();
     updateATEM();
+    if(AtemSwitcher.getProgramInput() == 2){
+        AtemSwitcher.changeAudioChannelMode(1101,0); //Mute Studio Audio
+        AtemSwitcher.changeAudioChannelMode(2,1); //UnMute Pi Audio
+    } else{
+        AtemSwitcher.changeAudioChannelMode(1101,1); //UnMute Studio Audio
+        AtemSwitcher.changeAudioChannelMode(2,0); //Mute Pi Audio
+    }
 }
 
 void readMic(uint8_t index) {
@@ -278,14 +285,6 @@ void updateATEM() {
                 AtemSwitcher.doAuto();
             } else {
                 AtemSwitcher.doCut();
-            }
-
-            if(videoSourceState == 2){
-                AtemSwitcher.changeAudioChannelMode(1101,0); //Mute Studio Audio
-                AtemSwitcher.changeAudioChannelMode(2,1); //UnMute Pi Audio
-            } else{
-                AtemSwitcher.changeAudioChannelMode(1101,1); //UnMute Studio Audio
-                AtemSwitcher.changeAudioChannelMode(2,0); //Mute Pi Audio
             }
 
             doCut = false;


### PR DESCRIPTION
When the program output is set to Aux (input 2), atem will mute the studio audio (external input), and un-mute aux audio (input 2).

If the program output is anything else then the studio audio is un-muted and the aux audio is muted.

This is checked on every cycle of the main loop. I tried this on the cut and this did not work for all of the switches.  This also has the advantage of muting the audio if the angles are controlled from ATEM software, providing the switcher is connected.